### PR TITLE
Add missing standard deployment protection key

### DIFF
--- a/Shared/Models/VercelProjectModel.swift
+++ b/Shared/Models/VercelProjectModel.swift
@@ -83,7 +83,9 @@ extension VercelProject {
 }
 
 enum DeploymentTypeProtection: String, Codable {
-	case preview, all
+	case standard = "prod_deployment_urls_and_all_previews"
+	case preview
+	case all
 }
 
 struct VercelEnv: Codable, Identifiable, Hashable {


### PR DESCRIPTION
Like many other users, my projects have disappeared from the Zeitgeist app recently. All of my projects have [Deployment Protection](https://vercel.com/docs/security/deployment-protection) setup to require Vercel authorization to preview deployments and any other domains except the most recent production deployment, which in Vercel parlance is "[Standard Protection](https://vercel.com/docs/security/deployment-protection#protecting-preview-and-generated-urls-with-standard-protection)."

The `DeploymentTypeProtection` enum currently only handles `preview` and `all` values for the API response, resulting in a decoding failure if a user has Standard Protection enabled on any of their projects. This PR adds support for the new value returned by the Vercel API for projects with Standard Protection enabled.